### PR TITLE
Preserve original file name on API 33+ by switching to SAF picker

### DIFF
--- a/app/src/main/java/compress/joshattic/us/CompressorViewModel.kt
+++ b/app/src/main/java/compress/joshattic/us/CompressorViewModel.kt
@@ -416,7 +416,43 @@ class CompressorViewModel(application: Application) : AndroidViewModel(applicati
     private var compressionJob: Job? = null
     private var activeTransformer: Transformer? = null
 
+    private fun queryDisplayName(context: Context, uri: Uri): String? {
+        val raw = try {
+            context.contentResolver.query(
+                uri,
+                arrayOf(android.provider.OpenableColumns.DISPLAY_NAME),
+                null, null, null
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) cursor.getString(idx) else null
+                } else null
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+        // Reject Photo Picker synthetic IDs (e.g. "1000040501") — these are MediaStore IDs,
+        // not real filenames. The picker hides the actual name for privacy on Android 13+.
+        if (raw.isNullOrBlank() || raw.matches(Regex("""^\d{6,}$"""))) return null
+        return raw
+    }
+
+    private fun sanitizeFilename(name: String): String =
+        name.replace(Regex("""[/\\:*?"<>|\x00-\x1F]"""), "_").trim().ifBlank { "Video" }
+
+    private fun makeOutputName(originalName: String?): String {
+        val base = originalName?.substringBeforeLast(".")?.takeIf { it.isNotBlank() }
+            ?.let { sanitizeFilename(it) }
+            ?: "Video_${System.currentTimeMillis()}"
+        return "${base}_Compressed.mp4"
+    }
+
     fun updateSelectedUri(context: Context, uri: Uri) {
+        // Resolve the display name independently — if metadata extraction throws below
+        // (HDR videos, unsupported codecs, slow URIs), we still keep the original name.
+        val originalName = queryDisplayName(context, uri)
+
         var size = 0L
         var width = 0
         var height = 0
@@ -425,8 +461,7 @@ class CompressorViewModel(application: Application) : AndroidViewModel(applicati
         var fps = 30f
         var videoMime: String? = null
         var duration = 0L
-        var originalName: String? = null
-        
+
         try {
             audioBitrate = getAudioBitrate(context, uri)
             val videoInfo = getVideoTrackInfo(context, uri)
@@ -458,15 +493,6 @@ class CompressorViewModel(application: Application) : AndroidViewModel(applicati
             }
             if (fps <= 0f) {
                 fps = 30f
-            }
-
-            val cursor = context.contentResolver.query(uri, null, null, null, null)
-            if (cursor != null && cursor.moveToFirst()) {
-                val nameIndex = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
-                if (nameIndex != -1) {
-                    originalName = cursor.getString(nameIndex)
-                }
-                cursor.close()
             }
 
             retriever.release()
@@ -713,8 +739,7 @@ class CompressorViewModel(application: Application) : AndroidViewModel(applicati
 
         val outputDir = File(context.cacheDir, "compressed_videos")
         outputDir.mkdirs()
-        val baseName = currentState.originalName?.substringBeforeLast(".") ?: "Compressed_${System.currentTimeMillis()}"
-        val outputFile = File(outputDir, "${baseName}_Compressed.mp4")
+        val outputFile = File(outputDir, makeOutputName(currentState.originalName))
         if (outputFile.exists()) {
             outputFile.delete()
         }
@@ -1117,12 +1142,7 @@ class CompressorViewModel(application: Application) : AndroidViewModel(applicati
                     return@launch
                 }
 
-                val targetName = if (currentState.originalName != null) {
-                    val nameWithoutExt = currentState.originalName.substringBeforeLast(".")
-                    "${nameWithoutExt}_Compressed.mp4"
-                } else {
-                    "Compressed_${System.currentTimeMillis()}.mp4"
-                }
+                val targetName = makeOutputName(currentState.originalName)
 
                 val values = ContentValues().apply {
                     put(MediaStore.Video.Media.DISPLAY_NAME, targetName)

--- a/app/src/main/java/compress/joshattic/us/MainActivity.kt
+++ b/app/src/main/java/compress/joshattic/us/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
@@ -160,8 +159,14 @@ fun CompressorApp(viewModel: CompressorViewModel) {
         }
     }
     
-    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+    // SAF-based picker — preserves the real file name (Photo Picker hides it for privacy on API 33+).
+    val pickMedia = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
+            try {
+                context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } catch (_: SecurityException) {
+                // Some providers don't grant persistable URIs; the URI is still readable for this session.
+            }
             viewModel.updateSelectedUri(context, uri)
         }
     }
@@ -241,7 +246,7 @@ fun CompressorApp(viewModel: CompressorViewModel) {
                         when(index) {
                             0 -> EmptyScreen(
                                 totalSaved = state.formattedTotalSaved,
-                                onPick = { pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly)) }
+                                onPick = { pickMedia.launch(arrayOf("video/*")) }
                             )
                             2 -> {
                                 if (state.error != null) {


### PR DESCRIPTION
## Summary

The recently added "preserve original file name" feature produces filenames like `1000040501_Compressed.mp4` instead of e.g. `PXL_20260316_124917401~2_Compressed.mp4` when the source video is selected through the in-app Photo Picker. This PR fixes that by switching the picker to SAF (`ActivityResultContracts.OpenDocument`).

## Root cause

`ActivityResultContracts.PickVisualMedia()` on Android 13+ returns picker URIs of the form `content://media/picker/0/com.android.providers.media.photopicker/media/<ID>`. Querying `OpenableColumns.DISPLAY_NAME` on these URIs returns the picker's synthetic numeric ID, not the real filename — by design, for privacy. The previous version then used that numeric ID as the "original name", producing the `1000040501_Compressed.mp4` style output observed on a Pixel 8 Pro (Android 16).

Looking it up confirmed the suspicion: MediaStore ID `1000040501` corresponds to a real video `PXL_20260316_124917401~2.mp4`. The app has no `READ_MEDIA_VIDEO` permission (intentionally — see README "no invasive permissions"), so it cannot resolve the ID back to the real name itself.

## Fix

- Replace `PickVisualMedia` with `OpenDocument(arrayOf("video/*"))`. SAF returns the real `DISPLAY_NAME`, requires no extra permissions, and works uniformly across API levels.
- Take a persistable URI permission so the picked URI survives configuration changes.

## Bonus hardening (same area, low risk)

These were noticed while tracing the bug and are included to make the feature resilient to a few related edge cases:

- Extract `DISPLAY_NAME` **before** the `MediaMetadataRetriever` block, so a thrown `setDataSource`/`extractMetadata` (HDR videos, unusual codecs) no longer silently discards the original name.
- Use a specific projection and `.use { }` for the cursor (was a `null` projection with manual `close()`; cursor was leaked on empty/exception paths).
- Reject obviously synthetic numeric `DISPLAY_NAME`s (`^\d{6,}$`) as a defense in depth.
- Sanitize filesystem-illegal characters from the base name (`/ \ : * ? " < > | \x00–\x1F`).
- Unify cache file and gallery save naming through a single helper, so the fallback never produces the previous `Compressed_<ts>_Compressed.mp4` double marker.

## Test plan

- [x] Build and install on Pixel 8 Pro (Android 16, API 36).
- [x] Pick a video via the new picker → output filename is the real source name plus `_Compressed.mp4` (e.g. `PXL_20260316_124917401~2_Compressed.mp4`).
- [x] No new permissions requested; existing share-intent path unchanged.
- [ ] Behavior on API 28- (legacy SAF save flow) — unchanged code path; not retested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)